### PR TITLE
Publish v4.0.1, addressing greedy .gitignore file restrictions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
-﻿# all folders starting with _ are local
+﻿# All folders starting with `_` are local
 _*/
 
-# byte-compiled python files
+# Byte-compiled Python files
 *.py[cod]
 
-# packman package files
+# Packman package files
 *@*.7z
 *@*.zip
 
-# binaries
+# Binaries
 *.ico
 *.bmp
 *.gif
@@ -33,19 +33,24 @@ _*/
 *.mat
 *.suo
 
-# visual studio filfes
+# Visual Studio files
 /.vs
 **/.vscode/ipch
 
 # PACKAGE-LICENSES/
 PACKAGE-DEPS.yaml
 
-# generated files under usd-plugins/schema
+# All generated CMakeLists.txt files, other than reference sample schema plugins
+**/CMakeLists.txt
+!src/usd-plugins/schema/**/CMakeLists.txt
+!CMakeLists.txt
+
+# Generated files under usd-plugins/schema
 src/usd-plugins/schema/omniExampleSchema/generated
 src/usd-plugins/schema/omniExampleCodelessSchema/generated
 src/usd-plugins/schema/omniMetSchema/generated
 
-# generated files for hydra-plugins/omniWarpSceneIndex
+# Generated files for hydra-plugins/omniWarpSceneIndex
 src/hydra-plugins/omniWarpSceneIndex/__init__.py
 src/hydra-plugins/omniWarpSceneIndex/api.h
 src/hydra-plugins/omniWarpSceneIndex/generatedSchema.usda
@@ -57,6 +62,3 @@ src/hydra-plugins/omniWarpSceneIndex/warpComputationAPI.cpp
 src/hydra-plugins/omniWarpSceneIndex/warpComputationAPI.h
 src/hydra-plugins/omniWarpSceneIndex/wrapWarpComputationAPI.cpp
 src/hydra-plugins/omniWarpSceneIndex/wrapTokens.cpp
-
-# all generated CMakeLists.txt files
-**/CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+cmake_minimum_required(VERSION 3.23.1)
+
+project(usd-plugins CXX)
+
+# include our packman dependencies
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+include(PackmanDeps)
+
+# include NVIDIA Pixar Plugin build tools that simplify building OpenUSD plugins
+include(NvPxrPlugin)
+
+if (PXR_VERSION LESS_EQUAL 2311)
+    set(CMAKE_CXX_STANDARD 14)
+else()
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if (NV_USD)
+    # if NV_USD is on, we need to compile with the old C++ ABI
+    add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
+endif()
+
+# set target directories
+set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/_install")
+set(CMAKE_INSTALL_BINDIR "bin")
+set(CMAKE_INSTALL_LIBDIR "lib")
+set(CMAKE_INSTALL_INCLUDEDIR "include")
+
+add_subdirectory(src/usd-plugins/schema/omniExampleCodelessSchema)
+add_subdirectory(src/usd-plugins/schema/omniExampleSchema)
+add_subdirectory(src/usd-plugins/schema/omniMetSchema)

--- a/src/usd-plugins/schema/omniExampleCodelessSchema/CMakeLists.txt
+++ b/src/usd-plugins/schema/omniExampleCodelessSchema/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+openusd_schema(omniExampleCodelessSchema
+    GENERATE_SCHEMA
+    SCHEMA_FILE
+        "${CMAKE_CURRENT_LIST_DIR}/schema.usda"
+)

--- a/src/usd-plugins/schema/omniExampleSchema/CMakeLists.txt
+++ b/src/usd-plugins/schema/omniExampleSchema/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../../../_install/omniExampleSchema")
+set(CMAKE_INSTALL_BINDIR "bin")
+set(CMAKE_INSTALL_LIBDIR "lib")
+set(CMAKE_INSTALL_INCLUDEDIR "include")
+openusd_schema(omniExampleSchema
+    GENERATE_SCHEMA
+    SCHEMA_FILE
+        "${CMAKE_CURRENT_LIST_DIR}/schema.usda"
+)

--- a/src/usd-plugins/schema/omniMetSchema/CMakeLists.txt
+++ b/src/usd-plugins/schema/omniMetSchema/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+openusd_schema(omniMetSchema
+    GENERATE_SCHEMA
+    SCHEMA_FILE
+        "${CMAKE_CURRENT_LIST_DIR}/schema.usda"
+)


### PR DESCRIPTION
# Description
This Pull Request addresses configuration issues with the repository's `.gitignore` file, which caused `CMakeLists.txt` files for the included [OpenUSD Schema plugin samples](https://github.com/NVIDIA-Omniverse/OpenUSD-plugin-samples/tree/ff12d07a841ab40a032f9a050952f65d466efdb7/src/usd-plugins/schema) from being included in the `v.4.0.0` submission. This unfortunately prevented contributors from successfully building said plugins due to incomplete CMake build configuration.

# Changes
The main changes included in the Pull Request include:
 - Removing restrictions from the `.gitignore` file which prevented `CMakeLists.txt` files from being submitted.
 - Including `CMakeLists.txt` files for OpenUSD Schema plugin samples (whose sources were already included in `v.4.0.0`).